### PR TITLE
Copter: Added LED disarm pattern request - AF-25

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -697,10 +697,19 @@ void ToyMode::blink_update(void)
     // when we blink rapidly
     if (copter.motors->armed() && AP_Notify::flags.failsafe_battery) {
         pattern = BLINK_8;
-    } else {
+    }
+    else if(!copter.motors->armed() && (blink_disarm > 0)){
+		pattern = BLINK_8;
+		blink_disarm--;
+	}
+    else{
         pattern = BLINK_FULL;
     }
-
+    
+    if(copter.motors->armed()){
+		blink_disarm = 4;
+	}
+    
     if (red_blink_count == 0) {
         red_blink_pattern = pattern;
     }

--- a/ArduCopter/toy_mode.h
+++ b/ArduCopter/toy_mode.h
@@ -122,6 +122,7 @@ private:
     uint8_t green_blink_index;
     uint16_t red_blink_count;
     uint16_t green_blink_count;
+    uint16_t blink_disarm;
 
     // remember the last mode we set
     control_mode_t last_set_mode = LOITER;


### PR DESCRIPTION
My attempt to resolve this bug - https://srtoys.atlassian.net/projects/AF/issues/AF-25?filter=allopenissues

It was requested the led on the frame should blink twice when the state of the drone goes from arm to disarm.