### PR TITLE
Copter: fence is set false when switch to LOITER fails

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -564,6 +564,11 @@ void ToyMode::update()
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ERROR, "Tmode: LANDING");
                 set_and_remember_mode(LAND, MODE_REASON_TMODE);
             }
+            else if(new_mode == LOITER)
+            {
+				//if in GPS denied environment and we are trying switch to LOITER then disable fence.
+				copter.fence.enable(false);
+			}
         }
     }
 }


### PR DESCRIPTION
The copter was not arming after it has failed to switch to loiter in a GPS denied environment and landed because the fence was being set to true when toggle button to switch to loiter is pressed. This is my attempted fix do disable the fence when it failed to switch to loiter in a GPS denied environment. 