### PR TITLE
Copter: attempt to improve setting home location while in indoor mode

### DIFF
--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -49,6 +49,16 @@ void Copter::fence_check()
         Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_FENCE, new_breaches);
     }
 
+#if TOY_MODE_ENABLED == ENABLED
+    if (g2.toy_mode.enabled() && control_mode == LOITER && !fence.check_destination_within_fence(copter.current_loc)) {
+        // in toy mode we unconditionally RTL when we are in LOITER
+        // mode outside the fence. This covers a case where the user
+        // enters LOITER mode outside the fence after the fence was
+        // disabled in ALT_HOLD mode
+        set_mode(RTL, MODE_REASON_FENCE_BREACH);
+    }
+#endif
+    
     // record clearing of breach
     if(orig_breaches != AC_FENCE_TYPE_NONE && fence.get_breaches() == AC_FENCE_TYPE_NONE) {
         Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_FENCE, ERROR_CODE_ERROR_RESOLVED);

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -193,11 +193,16 @@ void ToyMode::update()
         load_test.running = false;
     }
         
-    //prevent geofence being enabled when in ALT_HOLD mode
+    // prevent geofence being enabled when in ALT_HOLD mode
     if (copter.control_mode == ALT_HOLD) { 
-		copter.fence.enable(false); 
-	}
+        copter.fence.enable(false); 
+    }
 
+    // force geofence on when in LOITER mode
+    if (copter.control_mode == LOITER) { 
+        copter.fence.enable(true); 
+    }
+    
     // keep filtered battery voltage for thrust limiting
     filtered_voltage = 0.99 * filtered_voltage + 0.01 * copter.battery.voltage();
     
@@ -423,7 +428,7 @@ void ToyMode::update()
     }
 
     if (copter.control_mode == RTL && (flags & FLAG_RTL_CANCEL) && throttle_near_max &&
-        !copter.fence.check_fence(copter.current_loc.alt/100.0f)) {
+        copter.fence.check_destination_within_fence(copter.current_loc)) {
         GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Tmode: RTL cancel");        
         set_and_remember_mode(LOITER, MODE_REASON_TMODE);
     }

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -416,6 +416,30 @@ void ToyMode::update()
     } else {
         throttle_high_counter = 0;
     }
+    
+     /*
+     * attemp to improve the setting of home location if it takes off when EKF is not happy
+     */
+    //           
+    if(copter.motors->armed() && !copter.position_ok()){
+        // if we have a 3d lock and valid location
+        if(copter.gps.status() >= AP_GPS::GPS_OK_FIX_3D){
+            //aquire horizontal accuracy
+            float toy_horizontal_acc;
+            copter.gps.horizontal_accuracy(toy_horizontal_acc);
+            //if gps horizontal accuracy of below 15m
+            if(toy_horizontal_acc <= 1500){
+                //if home location has not been set yet
+                if(copter.ap.home_state == HOME_UNSET){
+                    //bypass EKF check and set currect location as HOME location
+                    Location indoor_loc = copter.gps.location(); 
+                    copter.ahrs.set_home(indoor_loc);
+                    copter.set_home_state(HOME_SET_NOT_LOCKED);
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "INDOOR MODE: setting home location here");
+                }
+            }
+        }
+    }
 
     if (upgrade_to_loiter) {
         if (!copter.motors->armed() || copter.control_mode != ALT_HOLD) {


### PR DESCRIPTION
As mentioned:

It should set current location as drone home location when it has 3D GPS lock and horizontal accuracy is below 15m and set "home state" as HOME_SET_NOT_LOCKED

I found that in commands.cpp there is a check that if home state is already set it wont re-set the home location. - https://github.com/SkyRocketToys/ardupilot/blob/master/ArduCopter/commands.cpp#L14