### PR TITLE
Copter: attempt to improve setting home location if we take off in hybrid mode

### DIFF
--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -426,7 +426,7 @@ void ToyMode::update()
             //aquire horizontal accuracy
             float toy_horizontal_acc;
             if (copter.gps.horizontal_accuracy(toy_horizontal_acc)) {
-                //if gps horizontal accuracy of below 1500mm
+                //if gps horizontal accuracy of below 1500cm
                 if(toy_horizontal_acc <= 1500){
                     //if home location has not been set yet
                     if (copter.ap.home_state == HOME_UNSET) {

--- a/ArduCopter/toy_mode.cpp
+++ b/ArduCopter/toy_mode.cpp
@@ -416,6 +416,29 @@ void ToyMode::update()
     } else {
         throttle_high_counter = 0;
     }
+    
+    /*
+    * attemp to improve the setting of home location if it takes off when EKF is not happy
+    */
+    if(copter.motors->armed() && !copter.position_ok()){
+        // if we have a 3d lock and valid location
+        if(copter.gps.status() >= AP_GPS::GPS_OK_FIX_3D){
+            //aquire horizontal accuracy
+            float toy_horizontal_acc;
+            copter.gps.horizontal_accuracy(toy_horizontal_acc);
+            //if gps horizontal accuracy of below 15m
+            if(toy_horizontal_acc <= 1500){
+                //if home location has not been set yet
+                if(copter.ap.home_state == HOME_UNSET){
+                    //bypass EKF check and set currect location as HOME location
+                    Location indoor_loc = copter.gps.location(); 
+                    copter.ahrs.set_home(indoor_loc);
+                    copter.set_home_state(HOME_SET_NOT_LOCKED);
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "INDOOR MODE: setting home location here");
+                }
+            }
+        }
+    }
 
     if (upgrade_to_loiter) {
         if (!copter.motors->armed() || copter.control_mode != ALT_HOLD) {

--- a/ArduCopter/toy_mode.h
+++ b/ArduCopter/toy_mode.h
@@ -168,5 +168,8 @@ private:
         AP_Int8  load_type;
     } load_test;
     
+    //for storing location in indoor mode
+    Location indoor_loc;
+    
     static const struct load_data load_data1[];
 };


### PR DESCRIPTION
I have applied the changes that was mentioned in the previous PR and added some code to correct the altitude when EKF is happy with GPS. With the previous code, it sometimes find itself outside the fence when it gets FULL GPS after it took took off/arm in indoor mode. 



 

