### PR TITLE
Copter: Attempt to improve the way the copter sets the home position

### DIFF
--- a/ArduCopter/toy_mode.h
+++ b/ArduCopter/toy_mode.h
@@ -122,6 +122,9 @@ private:
     bool upgrade_to_loiter;
     uint32_t last_action_ms;
     uint32_t reset_turtle_start_ms;
+    
+    //for storing location in indoor mode
+    Location indoor_loc;
 
     // time when we were last told we are recording video
     uint32_t last_video_ms;


### PR DESCRIPTION
To test this PR:

1.Ready two PC/Phone to connect to the web server on the drone. I used two phones for my test- one connects to the web server using google chrome to see the status text and one connects with the skyviper video viewer app to check where it sets the home location.
2.connect the battery to drone and turn on tx
3.on you pc/phone, connect the 1st PC/Phone to the web server on the drone via wifi. 
4.using your any web browser (I used chrome) navigate to 192.168.99.1
5.navigate to system status>>message
6.arm or arm and hover the drone in alt_hold mode
7.keep an eye on the message tab - you should get the "INDOOR MODE:set home loc with horizontal_acc:" message
8.fly forward or in any direction which is considerable far from you i.e. 30meter away before it gets full gps lock/EKF happy
9. wait for the drone to get full gps lock/ EKF happy
10. connect your 2nd PC/Phone to the drone and launch either mission planner if you are using PC or sky viper video viewer app if you are using a phone.
11. check if the home location is near you and make sure it did not set home location in some part of the world.
12. if home is nearby then RTL if not manually control the drone and land it safely 

I have attached my test video and some logs on that flight for your reference
https://drive.google.com/open?id=0B3_WlAMsda15R25KTl96ejJXbDQ


